### PR TITLE
Feat 34 http only 헤더 적용

### DIFF
--- a/backend/src/main/java/com/example/demo/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/controller/AuthController.java
@@ -6,10 +6,16 @@ import com.example.demo.domain.auth.dto.request.ResetPasswordRequest;
 import com.example.demo.domain.auth.dto.request.SignUpRequest;
 import com.example.demo.domain.auth.dto.response.TokenResponse;
 import com.example.demo.domain.auth.service.AuthService;
+import com.example.demo.global.jwt.JwtProvider;
 import com.example.demo.global.response.RsData;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -17,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/signup")
     public RsData<?> signUp(@RequestBody @Valid SignUpRequest request) {
@@ -25,21 +32,57 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public RsData<TokenResponse> login(@RequestBody @Valid LoginRequest request) {
+    public ResponseEntity<RsData<TokenResponse>> login(@RequestBody @Valid LoginRequest request) {
         TokenResponse tokens = authService.login(request);
-        return new RsData<>("200", "로그인 완료되었습니다.", tokens);
+
+        // HttpOnly 쿠키 설정
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true) // avaScript에서 접근 불가.
+                //.secure(true) // HTTPS 사용 시
+                .path("/")
+                .maxAge(Duration.ofMillis(jwtProvider.getRefreshTokenExpirationInMillis()))
+                .sameSite("Strict") // 또는 Lax/None
+                .build();
+
+        return  ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(new RsData<>("200", "로그인 완료되었습니다.", tokens.withoutRefreshToken()));
     }
 
     @PostMapping("/logout")
-    public RsData<?> logout(@RequestHeader(value = "Authorization",required = false) String authHeader) {
+    public ResponseEntity<RsData<?>> logout(@RequestHeader(value = "Authorization", required = false) String authHeader) {
         authService.logout(authHeader);
-        return new RsData<>("200", "로그아웃 완료되었습니다.");
+
+        // refreshToken 쿠키 삭제
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                //.secure(true)
+                .path("/")
+                .maxAge(0) // 쿠키 즉시 만료
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                .body(new RsData<>("200", "로그아웃 완료되었습니다."));
     }
 
+    // @CookieValue를 통해 클라이언트가 보내는 HttpOnly 쿠키에서 Refresh Token을 읽음
     @PostMapping("/reissue")
-    public RsData<TokenResponse> reissue(@CookieValue("refreshToken") String refreshToken) {
+    public ResponseEntity<RsData<TokenResponse>> reissue(@CookieValue("refreshToken") String refreshToken) {
         TokenResponse tokens = authService.reissue(refreshToken);
-        return new RsData<>("200", "토큰 재발행 완료되었습니다.", tokens);
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                //.secure(true)  // HTTPS 환경에서만 true, 로컬 개발시 false 가능
+                .path("/")
+                .maxAge(Duration.ofMillis(jwtProvider.getRefreshTokenExpirationInMillis()))
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(new RsData<>("200", "토큰 재발행 완료되었습니다.", tokens.withoutRefreshToken()));
     }
 
     @PostMapping("change-password")

--- a/backend/src/main/java/com/example/demo/domain/auth/dto/response/TokenResponse.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/dto/response/TokenResponse.java
@@ -2,4 +2,8 @@ package com.example.demo.domain.auth.dto.response;
 
 public record TokenResponse(
         String accessToken, String refreshToken
-) {}
+)   {
+    public TokenResponse withoutRefreshToken() {
+    return new TokenResponse(this.accessToken, null);
+    }
+}

--- a/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
@@ -129,6 +129,10 @@ public class AuthService {
                 .orElseThrow(UserNotFoundException::new);
 
         String newAccessToken = jwtProvider.generateAccessToken(email, user.getRole());
+        String newRefreshToken = jwtProvider.generateRefreshToken(email, user.getRole());
+
+        // Redis에 새 refreshToken 저장, 기존 토큰 덮어쓰기
+        redisTokenRepository.saveRefreshToken(email, newRefreshToken, jwtProvider.getRefreshTokenExpirationInMillis());
 
         return new TokenResponse(newAccessToken, refreshToken);
     }

--- a/backend/src/main/java/com/example/demo/domain/major/controller/MajorController.java
+++ b/backend/src/main/java/com/example/demo/domain/major/controller/MajorController.java
@@ -1,13 +1,10 @@
 package com.example.demo.domain.major.controller;
 
-import com.example.demo.domain.major.entity.Major;
-import com.example.demo.domain.major.repository.MajorRepository;
 import com.example.demo.domain.major.response.MajorResponse;
 import com.example.demo.domain.major.service.MajorService;
 import com.example.demo.global.response.RsData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +17,7 @@ public class MajorController {
 
     private final MajorService majorService;
 
-    @PostMapping("/list")
+    @GetMapping("/list")
     public RsData<?> getAllMajors() {
         List<MajorResponse> majors = majorService.getAllMajors();
         return new RsData<>("200", "전공 목록 조회 성공", majors);


### PR DESCRIPTION
## ✨ 변경 사항 설명
1.http only 헤더 적용
2. 리프레시토큰을 헤더에 담고 json에는 액세스 토큰만 담아 보내줌
3. reissue시 리프레시토큰도 재발급 하도록 하였음
<!-- 🔍 이 PR에서 변경된 내용을 간략하게 설명해주세요. -->

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
