### PR TITLE
Refector 56 : User및 회원가입 DTO 받아야 할 정보 다 적용 및 버그 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/domain/auth/dto/request/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/dto/request/PasswordChangeRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record PasswordChangeRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        String email,
+
         @NotBlank(message = "현재 비밀번호는 필수입니다.")
         String currentPassword,
 

--- a/backend/src/main/java/com/example/demo/domain/auth/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/dto/request/SignUpRequest.java
@@ -2,9 +2,32 @@ package com.example.demo.domain.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record SignUpRequest(
-        @Email String email,
-        @NotBlank String password,
-        @NotBlank String name
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        // 비밀번호 정규식 (예: 영문, 숫자, 특수문자 포함 8~20자)
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~20자여야 합니다.")
+        String password,
+
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @NotBlank(message = "학번은 필수입니다.")
+        String studentId,
+
+        @NotBlank(message = "전공은 필수입니다.")
+        String majorName,
+
+        @NotNull(message = "학년은 필수입니다.")
+        Integer grade,
+
+        @NotNull(message = "학기는 필수입니다.")
+        Integer semester
 ) {}

--- a/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
@@ -5,10 +5,14 @@ import com.example.demo.domain.auth.dto.request.ResetPasswordRequest;
 import com.example.demo.domain.auth.dto.request.SignUpRequest;
 import com.example.demo.domain.auth.dto.response.TokenResponse;
 import com.example.demo.domain.auth.exception.*;
+import com.example.demo.domain.major.entity.Major;
+import com.example.demo.domain.major.exception.MajorNotFoundException;
+import com.example.demo.domain.major.repository.MajorRepository;
 import com.example.demo.domain.user.entity.User;
 import com.example.demo.domain.user.entity.UserStatus;
 import com.example.demo.domain.user.repository.UserRepository;
 import com.example.demo.domain.user.role.Role;
+import com.example.demo.global.exception.AuthException;
 import com.example.demo.global.jwt.service.TokenService;
 import com.example.demo.global.redis.repository.RedisTokenRepository;
 import jakarta.validation.Valid;
@@ -31,6 +35,7 @@ public class AuthService {
     private final RedisTokenRepository redisTokenRepository;
     private final AuthenticationManager authenticationManager;
     private final TokenService tokenService;
+    private final MajorRepository majorRepository;
 
     @Transactional
     public void signUp(SignUpRequest request) {
@@ -45,10 +50,17 @@ public class AuthService {
             throw new EmailNotVerifiedException();
         }
 
+        Major major = majorRepository.findByName(request.majorName())
+                .orElseThrow(MajorNotFoundException::new);
+
         User user = User.builder()
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .name(request.name())
+                .studentId(request.studentId())
+                .major(major)
+                .grade(request.grade())
+                .semester(request.semester())
                 .role(Role.USER)
                 .status(UserStatus.ACTIVE)
                 .build();
@@ -115,6 +127,9 @@ public class AuthService {
 
         String token = authHeader.replace("Bearer ", "");
         String email = tokenService.getEmailFromToken(token);
+        if (!request.email().equals(email)) {
+            throw new AuthException("403","사용자 이메일과 토큰 이메일이 다릅니다");
+        }
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);

--- a/backend/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/backend/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -32,6 +32,13 @@ public class User {
     @Column(unique = true)
     private String studentId;
 
+    @Column(nullable = false)
+    private Integer grade;
+
+    @Column(nullable = false)
+    private Integer semester;
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "major_id")
     private Major major;
@@ -55,13 +62,11 @@ public class User {
         this.password = newEncodedPassword;
     }
 
-    public void updateProfile(String name, Major major) {
-        if (name != null) {
-            this.name = name;
-        }
-        if (major != null) {
-            this.major = major;
-        }
+    public void updateProfile(String name, Major major, Integer grade, Integer semester) {
+        if (name != null) this.name = name;
+        if (major != null) this.major = major;
+        if (grade != null) this.grade = grade;
+        if (semester != null) this.semester = semester;
     }
 
 }

--- a/backend/src/main/java/com/example/demo/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/demo/global/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.example.demo.global.jwt;
 
 import com.example.demo.domain.user.entity.User;
-import com.example.demo.domain.user.repository.UserRepository;
 import com.example.demo.domain.user.role.Role;
 import com.example.demo.global.exception.CustomJwtException;
 import com.example.demo.global.jwt.exception.JwtInvalidSignatureException;
@@ -29,9 +28,9 @@ import java.util.Objects;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final UserRepository userRepository;
     private final RedisTokenRepository redisTokenRepository;
-    //private final ObjectMapper objectMapper;
+
+
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/backend/src/main/java/com/example/demo/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/example/demo/global/jwt/JwtProvider.java
@@ -40,7 +40,7 @@
             key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         }
 
-//        // 개발용 주석임 지우지 말아줘
+        // 개발용 주석임 지우지 말아줘
 //        private final SecretKey key;
 //        private final long accessExpirationInSeconds;
 //        private final long refreshExpirationInSeconds;
@@ -97,8 +97,6 @@
                 return Jwts.parser()
                 //  검증용 키 등록(JWT의 Signature를 검증)
                         .verifyWith(getKey())
-                        // 현재 시간 기준으로 만료되었는지 검증
-                        .requireExpiration(new Date())
                 //  파서 객체 완성
                         .build()
                 //  토큰 파싱 + 서명 검증

--- a/backend/src/main/java/com/example/demo/global/jwt/service/TokenService.java
+++ b/backend/src/main/java/com/example/demo/global/jwt/service/TokenService.java
@@ -6,6 +6,7 @@ import com.example.demo.domain.auth.exception.UserNotFoundException;
 import com.example.demo.domain.user.entity.User;
 import com.example.demo.domain.user.repository.UserRepository;
 import com.example.demo.domain.user.role.Role;
+import com.example.demo.global.exception.CustomJwtException;
 import com.example.demo.global.jwt.JwtProvider;
 import com.example.demo.global.jwt.exception.JwtInvalidSignatureException;
 import com.example.demo.global.redis.repository.RedisTokenRepository;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -59,10 +61,10 @@ public class TokenService {
             throw new JwtInvalidSignatureException();
         }
 
-        String savedToken = redisTokenRepository.getRefreshToken(email);
-        if (!refreshToken.equals(savedToken)) {
-            throw new JwtInvalidSignatureException();
-        }
+
+        redisTokenRepository.getRefreshToken(email)
+                .filter(saved -> saved.equals(refreshToken))
+                .orElseThrow(JwtInvalidSignatureException::new);
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new);
@@ -103,6 +105,10 @@ public class TokenService {
 
     public long getRefreshExpirationInMillis() {
         return jwtProvider.getRefreshTokenExpirationInMillis();
+    }
+
+    public void validateRefreshToken(String refreshToken, String email) {
+        if (!Objects.equals(jwtProvider.extractEmail(refreshToken), email)) throw new JwtInvalidSignatureException();
     }
 }
 

--- a/backend/src/main/java/com/example/demo/global/redis/repository/RedisTokenRepository.java
+++ b/backend/src/main/java/com/example/demo/global/redis/repository/RedisTokenRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Repository
@@ -35,8 +36,8 @@ public class RedisTokenRepository {
     }
 
     // 리프레시 토큰값 가져옴
-    public String getRefreshToken(String email) {
-        return redisTemplate.opsForValue().get(REFRESH_PREFIX + email);
+    public Optional<String> getRefreshToken(String email) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(REFRESH_PREFIX + email));
     }
 
     // 리프레시 토큰 삭제


### PR DESCRIPTION
## ✨ 변경 사항 설명

<!-- 🔍 이 PR에서 변경된 내용을 간략하게 설명해주세요. -->

1. reissue시 무조건 토큰이 만료되게 작동하던거 고침
2. 회원가입시 주입받아야 할 정보들 전부 주입받고 user객체 생성하도록 변경

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
