### PR TITLE
Feat 144 비동기 상태 추적(메일 전송)

### DIFF
--- a/backend/src/main/java/com/example/demo/domain/mail/controller/MailController.java
+++ b/backend/src/main/java/com/example/demo/domain/mail/controller/MailController.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.mail.controller;
 
+import com.example.demo.domain.mail.dto.MailStatusResponse;
+import com.example.demo.domain.mail.entity.MailStatus;
 import com.example.demo.domain.mail.service.MailService;
 import com.example.demo.global.annotation.swagger.ApiErrorResponse;
 import com.example.demo.global.annotation.swagger.ApiSuccessResponse;
@@ -29,8 +31,40 @@ public class MailController {
     )
     @PostMapping("/email-verifications")
     public RsData<?> sendVerificationCode(@RequestParam("email") String email) {
-        mailService.sendVerificationCode(email);
-        return RsData.of("202", "인증 코드 발송요청 성공했습니다.");
+        try {
+            mailService.sendVerificationCode(email);
+            return RsData.of("202", "인증 코드 발송요청 성공했습니다.");
+        } catch (Exception e) {
+            // MailService에서 동기적으로 발생할 수 있는 예외 처리
+            // (예: Redis 연결 실패 등)
+            return RsData.of("500", "인증 코드 발송 요청에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "인증코드 이메일 발송 상태 확인", description = "이메일 전송은 비동기 스레드에서 처리하기에 상태추적하기위함")
+    @ApiSuccessResponse(description = "메일 발송 상태 조회. 전송요청 후 202 응답 받았으면 \n2초뒤 한번 1초뒤 한번 1초뒤 한번 이렇게 네번정도 요청하면 될듯\n" +
+            " PENDING:처리 중,\n" +
+            "    SUCCESS:성공\n," +
+            "    FAILED:실패"
+            ,message = "메일 발송 상태 조회 성공.", dataType = MailStatusResponse.class)
+    @ApiErrorResponse(
+            responseCode = "404",
+            description = "인증요청 한적 없음",
+            exampleName = "NotSendEmail",
+            exampleValue = "{\"code\": \"404\", " +
+                    "\"message\": \"인증 요청 기록을 찾을 수 없습니다.\"" +
+                    ", \"data\": null}"
+    )
+    @GetMapping("/status")
+    public RsData<MailStatusResponse> getMailStatus(@RequestParam String email) {
+        MailStatus status = mailService.getMailStatus(email);
+
+        if (status == null) {
+            // 아직 요청 기록이 없거나 만료된 경우
+            return RsData.of("404", "인증 요청 기록을 찾을 수 없습니다.");
+        }
+
+        return RsData.of("200", "메일 발송 상태 조회 성공", new MailStatusResponse(status.name()));
     }
 
     @Operation(summary = "인증코드 확인", description = "발송된 인증 코드를 사용하여 이메일 주소의 소유권을 확인합니다.")

--- a/backend/src/main/java/com/example/demo/domain/mail/dto/MailStatusResponse.java
+++ b/backend/src/main/java/com/example/demo/domain/mail/dto/MailStatusResponse.java
@@ -1,0 +1,6 @@
+package com.example.demo.domain.mail.dto;
+
+public record MailStatusResponse(
+        String status
+) {
+}

--- a/backend/src/main/java/com/example/demo/domain/mail/entity/MailStatus.java
+++ b/backend/src/main/java/com/example/demo/domain/mail/entity/MailStatus.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.mail.entity;
+
+public enum MailStatus {
+    PENDING, // 처리 중
+    SUCCESS, // 성공
+    FAILED   // 실패
+}

--- a/backend/src/main/java/com/example/demo/domain/mail/service/EmailSendingService.java
+++ b/backend/src/main/java/com/example/demo/domain/mail/service/EmailSendingService.java
@@ -9,6 +9,8 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.CompletableFuture;
+
 @Service
 @RequiredArgsConstructor
 public class EmailSendingService {
@@ -17,24 +19,23 @@ public class EmailSendingService {
 
     @Async("EmailThreadPoolTaskExecutor")
     // 인증 코드를 이메일로 발송
-    public void sendAuthCodeEmail(String email, String authCode) throws Exception {
+    public CompletableFuture<Void> sendAuthCodeEmail(String email, String authCode) throws Exception {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        try {
-            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-            mimeMessageHelper.setTo(email);
-            mimeMessageHelper.setSubject("[USWBook] 이메일 인증을 위한 인증 코드 발송");
 
-            // HTML 형식의 이메일 본문
-            String htmlContent = "<p>USWBook 인증코드 입니다.</p>"
-                    + "<p>인증을 완료하려면 아래의 6자리 코드를 입력해주세요.(유효기간은 30분입니다)</p>"
-                    + "<h2>" + authCode + "</h2>";
-            mimeMessageHelper.setText(htmlContent, true);
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        mimeMessageHelper.setTo(email);
+        mimeMessageHelper.setSubject("[USWBook] 이메일 인증을 위한 인증 코드 발송");
 
-            javaMailSender.send(mimeMessage);
+        // HTML 형식의 이메일 본문
+        String htmlContent = "<p>USWBook 인증코드 입니다.</p>"
+                + "<p>인증을 완료하려면 아래의 6자리 코드를 입력해주세요.(유효기간은 30분입니다)</p>"
+                + "<h2>" + authCode + "</h2>";
+        mimeMessageHelper.setText(htmlContent, true);
 
-        } catch (MessagingException e) {
-            //throw new MessagingFailException("메세지 발송에 실패했습니다.");
-            throw new Exception(e.getMessage());
-        }
+        javaMailSender.send(mimeMessage);
+
+        // 성공 시, 완료된 Future를 반환
+        return CompletableFuture.completedFuture(null);
+
     }
 }

--- a/backend/src/main/java/com/example/demo/domain/mail/service/MailService.java
+++ b/backend/src/main/java/com/example/demo/domain/mail/service/MailService.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.mail.service;
 
+import com.example.demo.domain.mail.entity.MailStatus;
 import com.example.demo.domain.mail.exception.InvalidOrExpiredVerificationCodeException;
 import com.example.demo.domain.mail.exception.MessagingFailException;
 import com.example.demo.domain.mail.exception.VerificationCodeNotRequestedException;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.concurrent.CompletableFuture;
 
 
 @Service
@@ -21,14 +23,32 @@ public class MailService {
     private static final long AUTH_CODE_EXPIRATION_MILLIS = 1800000L; // 30분
 
     @Transactional
-    public void sendVerificationCode(String email) {
+    public void sendVerificationCode(String email) throws Exception {
         String code = createAuthCode();
         redisTokenRepository.saveVerificationCode(email, code, AUTH_CODE_EXPIRATION_MILLIS);
-        try {
-            emailSendingService.sendAuthCodeEmail(email, code);
-        } catch (Exception e) {
-            throw new MessagingFailException(e.getMessage());
-        }
+
+        // 1. 비동기 작업 호출 직후, 상태를 PENDING으로 저장
+        redisTokenRepository.saveMailStatus(email, MailStatus.PENDING);
+
+        CompletableFuture<Void> emailResult = emailSendingService.sendAuthCodeEmail(email, code);
+
+        emailResult.thenAccept(voidResult -> {
+            // 작업 성공 시, 상태를 SUCCESS로 업데이트
+            redisTokenRepository.saveMailStatus(email, MailStatus.SUCCESS);
+            System.out.println(email + " 주소로 메일 발송 성공!");
+        });
+
+        emailResult.exceptionally(ex -> {
+            //  작업 실패 시, 상태를 FAILED로 업데이트
+            redisTokenRepository.saveMailStatus(email, MailStatus.FAILED);
+            System.err.println(email + " 주소로 메일 발송 실패: " + ex.getMessage());
+            return null;
+        });
+    }
+
+    //  상태 조회를 위한  메서드
+    public MailStatus getMailStatus(String email) {
+        return redisTokenRepository.getMailStatus(email);
     }
 
     @Transactional

--- a/backend/src/main/java/com/example/demo/global/redis/repository/RedisTokenRepository.java
+++ b/backend/src/main/java/com/example/demo/global/redis/repository/RedisTokenRepository.java
@@ -1,5 +1,6 @@
 package com.example.demo.global.redis.repository;
 
+import com.example.demo.domain.mail.entity.MailStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,6 +26,7 @@ public class RedisTokenRepository {
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String EMAIL_AUTH_PREFIX = "auth:code:";
     private static final String VERIFIED_EMAIL_PREFIX = "verified:";
+    private static final String EMAIL_STATUS_PREFIX = "mail_status:";
 
     // 리프레시 토큰 저장
     public void saveRefreshToken(String email, String refreshToken, long expirationInMillis) {
@@ -102,5 +104,18 @@ public class RedisTokenRepository {
     // 레디스에 토큰이 존재하는지 검증
     public boolean existsRefreshToken(String email) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_PREFIX + email));
+    }
+
+    // 메일 발송 상태 저장 (20분 유효시간)
+    public void saveMailStatus(String email, MailStatus status) {
+        String key = EMAIL_STATUS_PREFIX + email;
+        redisTemplate.opsForValue().set(key, status.name(), Duration.ofMinutes(20));
+    }
+
+    // 메일 발송 상태 조회
+    public MailStatus getMailStatus(String email) {
+        String key = EMAIL_STATUS_PREFIX + email;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        return status != null ? MailStatus.valueOf(status) : null;
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항 설명

이메일로 인증코드를 보내는것은 비동기로 진행중이였었고
메인스레드는 비동기 스레드에게 작업을 위임한 뒤 202 응답을 뱉고 세션을 종료시키기에 
프론트에게 비동기 스레드가 메일전송을 잘 하는지 상태를 알려줄 방법이 없었음.

그래서 따로 상태확인 요청 경로 추가하였음

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
