### PR TITLE
Reafactor 146 파라미터에러 잡는거 추가함

### DIFF
--- a/backend/src/main/java/com/example/demo/global/annotation/enums/EnumValidator.java
+++ b/backend/src/main/java/com/example/demo/global/annotation/enums/EnumValidator.java
@@ -6,7 +6,7 @@ import jakarta.validation.ConstraintValidatorContext;
 public class EnumValidator implements ConstraintValidator<Enum, String> {
 
     private Class<? extends java.lang.Enum<?>> enumClass;
-    private boolean ignoreCase;
+    private boolean ignoreCase; //false(기본값) 일경우 대소문자도 따짐
 
     @Override
     public void initialize(Enum annotation) {
@@ -22,13 +22,13 @@ public class EnumValidator implements ConstraintValidator<Enum, String> {
         }
 
         // Enum에 포함된 모든 상수들을 순회하며 입력값과 비교
-        return java.util.Arrays.stream(enumClass.getEnumConstants())
-                .anyMatch(enumConstant -> {
+        return java.util.Arrays.stream(enumClass.getEnumConstants()) //  Enum의 모든 상수를 가져와서
+                .anyMatch(enumConstant -> { //  그 중 하나라도(anyMatch) 아래 조건을 만족하는지 확인
                     if (ignoreCase) {
                         return enumConstant.name().equalsIgnoreCase(value);
                     } else {
                         return enumConstant.name().equals(value);
                     }
-                });
+                }); //  만족하는 상수가 '하나도 없으면' 최종적으로 false를 반환
     }
 }

--- a/backend/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -5,15 +5,13 @@ import com.example.demo.domain.mail.exception.TooManyMailRequestException;
 import com.example.demo.global.response.RsData;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.LazyInitializationException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
@@ -22,178 +20,156 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-import java.util.Map;
+import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 
 @Slf4j
 @RestControllerAdvice
-@RequiredArgsConstructor
 public class GlobalExceptionHandler {
-    private final HttpServletRequest request;
 
-    // 많은 요청이 들어올경우
-    @ExceptionHandler(TooManyMailRequestException.class)
-    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS) //  429 상태 코드
-    public RsData<String> handleTooManyMailRequestException(TooManyMailRequestException ex) {
-        return RsData.of("429", ex.getMessage());
-    }
+    // =================================================================================================================
+    //  4xx Client Error
+    // =================================================================================================================
 
     /**
-     * @RequestBody에 데이터가 없을 때 발생하는 예외를 처리합니다.
-     * 값이 하나도 없을떄 NULL일떄
+     * @Valid, @Validated 에 의한 유효성 검증 실패 시 (主に @RequestBody, @ModelAttribute)
      */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ExceptionHandler(BindException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public RsData<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
-        log.error("HttpMessageNotReadableException: {}", ex.getMessage());
-        return RsData.of("400-1", "요청 본문(Request Body)이 비어있거나 형식이 잘못되었습니다.");
+    public RsData<?> handleBindException(BindException ex) {
+        // 여러 에러 중 첫 번째 에러 정보를 가져옴
+        FieldError firstError = ex.getBindingResult().getFieldError();
+        if (firstError == null) {
+            return RsData.of("400-1", "입력값이 유효하지 않습니다.");
+        }
+
+        String errorMessage;
+        //  에러 코드 중에 "typeMismatch"가 포함되어 있는지 확인
+        if (Arrays.asList(Objects.requireNonNull(firstError.getCodes())).contains("typeMismatch")) {
+            //  타입 변환 실패 에러인 경우, 직접 만든 사용자 친화적인 메시지 사용
+            errorMessage = String.format("'%s' 필드에 유효하지 않은 형식의 값이 입력되었습니다.", firstError.getField());
+        } else {
+            //  그 외 @NotNull, @Email 등의 유효성 검증 에러인 경우, 어노테이션에 정의된 메시지 사용
+            errorMessage = firstError.getDefaultMessage();
+        }
+
+        return RsData.of("400-1", errorMessage);
     }
 
     /**
-     * @RequestParam에 데이터가 없을 때 발생하는 예외를 처리합니다.
-     * 파라미터가 빠진경우
+     * @RequestParam 필수 파라미터 누락 시
      */
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public RsData<String> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
-        log.error("MissingServletRequestParameterException: {}", ex.getMessage());
-        // 어떤 파라미터가 누락되었는지 동적으로 메시지를 생성해줍니다.
+    public RsData<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
         String message = String.format("필수 파라미터 '%s'가 누락되었습니다.", ex.getParameterName());
         return RsData.of("400-2", message);
     }
 
     /**
-     * @PathVariable 값의 타입이 일치하지 않을 경우 발생하는 예외를 처리합니다.
-     * ex) /api/posts/{postId} 에서 postId가 UUID 형식이 아닐 경우
+     * @RequestBody JSON 파싱 실패 또는 필수 본문 누락 시
      */
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST) // 400 에러로 응답 상태 코드 설정
-    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
-        String message = String.format("'%s' 파라미터의 형식이 잘못되었습니다. 올바른 형식은 '%s' 입니다.",
-                ex.getName(), Objects.requireNonNull(ex.getRequiredType()).getSimpleName());
-
-        ErrorResponse errorResponse = new ErrorResponse("400", message);
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RsData<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        return RsData.of("400-3", "요청 본문(Request Body)의 형식이 잘못되었거나 비어있습니다.");
     }
-
-    // 간단한 에러 응답 DTO
-    public record ErrorResponse(String code, String message) {}
 
     /**
-     * @CookieValue 어노테이션에서 required=true로 설정된 쿠키가 없을 때 발생하는 예외를 처리합니다.
-     * 500 Internal Server Error 대신, 명확한 400 Bad Request를 응답합니다.
+     * @PathVariable, @RequestParam 등 타입 변환 실패 시
      */
-    @ExceptionHandler(MissingRequestCookieException.class)
-    public ResponseEntity<RsData<Object>> handleMissingRequestCookieException(MissingRequestCookieException ex) {
-        String cookieName = ex.getCookieName();
-        String errorMessage = String.format("필수 쿠키 '%s'가 요청에 포함되지 않았습니다.", cookieName);
-
-        RsData<Object> response = RsData.of("400", errorMessage);
-
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RsData<?> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        String message = String.format("'%s' 파라미터의 타입이 잘못되었습니다. '%s' 타입이어야 합니다.",
+                ex.getName(), Objects.requireNonNull(ex.getRequiredType()).getSimpleName());
+        return RsData.of("400-4", message);
     }
 
-    // Auth 예외
+    /**
+     * 필수 쿠키 누락 시
+     */
+    @ExceptionHandler(MissingRequestCookieException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RsData<?> handleMissingRequestCookieException(MissingRequestCookieException ex) {
+        String errorMessage = String.format("필수 쿠키 '%s'가 요청에 포함되지 않았습니다.", ex.getCookieName());
+        return RsData.of("400-5", errorMessage);
+    }
+
+    /**
+     * 커스텀 Enum 유효성 검증 실패 시
+     */
+    @ExceptionHandler(EnumException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RsData<?> handleEnumException(EnumException e) {
+        return RsData.of("400-6", e.getMessage());
+    }
+
+    /**
+     * 너무 잦은 요청 시 (커스텀 예외)
+     */
+    @ExceptionHandler(TooManyMailRequestException.class)
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+    public RsData<?> handleTooManyMailRequestException(TooManyMailRequestException ex) {
+        return RsData.of("429", ex.getMessage());
+    }
+
+    /**
+     * 인증 실패 (로그인 필요)
+     */
+    @ExceptionHandler(AuthenticationException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public RsData<?> handleAuthenticationException(AuthenticationException e) {
+        return RsData.of("401", "인증에 실패했습니다. 로그인이 필요합니다.");
+    }
+
+    /**
+     * 인가 실패 (권한 없음)
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public RsData<?> handleAccessDeniedException(AccessDeniedException e) {
+        return RsData.of("403", "접근 권한이 없습니다.");
+    }
+
+    /**
+     * JPA 엔티티 조회 실패
+     */
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public RsData<?> handleEntityNotFoundException(EntityNotFoundException e) {
+        return RsData.of("404", "해당 데이터를 찾을 수 없습니다.");
+    }
+
+    // =================================================================================================================
+    //  동적 상태 코드 처리가 필요한 커스텀 예외 (ResponseEntity 유지)
+    // =================================================================================================================
+
     @ExceptionHandler(AuthException.class)
-    public ResponseEntity<RsData<Void>> handleAuthException(AuthException e) {
-        return ResponseEntity
-                //.status(HttpStatus.CONFLICT)
-                .status(e.getStatusCode())
-                .body(RsData.of(e.getCode(), e.getMessage()));
+    public ResponseEntity<RsData<?>> handleAuthException(AuthException e) {
+        return ResponseEntity.status(e.getStatusCode()).body(RsData.of(e.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(CustomJwtException.class)
-    public ResponseEntity<RsData<Void>> handleJwtException(CustomJwtException e) {
-        return ResponseEntity.status(e.getStatusCode())
-                .body(RsData.of(e.getCode(), e.getMessage()));
+    public ResponseEntity<RsData<?>> handleJwtException(CustomJwtException e) {
+        return ResponseEntity.status(e.getStatusCode()).body(RsData.of(e.getCode(), e.getMessage()));
     }
 
-    // 도메인 커스텀 예외
     @ExceptionHandler(BookException.class)
-    public ResponseEntity<RsData<Void>> handleBookException(BookException e) {
-        return ResponseEntity.status(e.getStatusCode())
-                .body(RsData.of(e.getCode(), e.getMessage()));
+    public ResponseEntity<RsData<?>> handleBookException(BookException e) {
+        return ResponseEntity.status(e.getStatusCode()).body(RsData.of(e.getCode(), e.getMessage()));
     }
 
-    // @Valid 검증 예외
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<RsData<Void>> handleValidationException(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getFieldErrors().stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(", "));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(RsData.of("400", message.isBlank() ? "잘못된 요청입니다." : message));
-    }
+    // =================================================================================================================
+    // ⭐️ 5xx Server Error
+    // =================================================================================================================
 
-    // 인증 / 인가 예외
-    @ExceptionHandler({AuthenticationException.class, AccessDeniedException.class})
-    public ResponseEntity<RsData<Void>> handleAuthorizationExceptions(Exception e) {
-        if (e instanceof AuthenticationException) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(RsData.of("401", "로그인이 필요합니다."));
-        }
-        if (e instanceof AccessDeniedException) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(RsData.of("403", "권한이 없습니다."));
-        }
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(RsData.of("403", "접근이 제한되었습니다."));
-    }
-
-    @ExceptionHandler(EnumException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public RsData<?> handleInvalidSemesterException(EnumException e) {
-        log.warn("잘못된 이넘 값 요청: {}", e.getMessage());
-        return RsData.of("400", e.getMessage());
-    }
-
-    // JPA 엔티티 조회 실패 (fallback)
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<RsData<Void>> handleEntityNotFoundException(EntityNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(RsData.of("404", "해당 데이터를 찾을 수 없습니다."));
-    }
-
-    // NoResourceFoundException을 잡아서 404 응답을 반환
-    @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<RsData<Void>> handleNoResourceFoundException(NoResourceFoundException e) {
-        //  log.warn("Static resource not found: {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(RsData.of("404", "요청하신 리소스를 찾을 수 없습니다."));
-    }
-
-    // 서버 내부 오류
-    @ExceptionHandler({LazyInitializationException.class, RuntimeException.class, Exception.class})
-    public ResponseEntity<RsData<Void>> handleServerError(Exception e) {
-        log.error("🔥 500 Internal Server Error", e);
-        String method = request.getMethod();
-        String path = request.getRequestURI();
-        String paramJson = extractParams(request);
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(RsData.of("500", "서버 오류가 발생했습니다."));
-    }
-
-    private String extractParams(HttpServletRequest req) {
-        String contentType = req.getContentType() == null ? "" : req.getContentType();
-        if (contentType.contains(MediaType.APPLICATION_JSON_VALUE)) {
-            String json = (String) req.getAttribute("cachedRequestBody");
-            return (json != null) ? StringUtils.abbreviate(json, 300) : "(빈 JSON 바디)";
-        }
-        if ("GET".equalsIgnoreCase(req.getMethod())) {
-            String qs = req.getQueryString();
-            return (qs != null && !qs.isBlank()) ? qs : "(쿼리스트링 없음)";
-        }
-        Map<String, String[]> map = req.getParameterMap();
-        if (!map.isEmpty()) {
-            return map.entrySet().stream()
-                    .map(e -> e.getKey() + ":" + String.join(",", e.getValue()))
-                    .collect(Collectors.joining("\n"));
-        }
-        return "(파라미터 없음)";
+    @ExceptionHandler({Exception.class})
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public RsData<?> handleAllUncaughtException(Exception e, HttpServletRequest request) { // 필요한 곳에서만 request를 파라미터로 받음
+        log.error("🔥 500 Internal Server Error 발생: {}", e.getMessage(), e);
+        log.error("Request: {} {}", request.getMethod(), request.getRequestURI()); // 요청 정보 로깅
+        return RsData.of("500", "서버 내부 오류가 발생했습니다.");
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항 설명

[REFACTOR: GlobalExceptionHandler 로직 개선 및 응답 일관성 확보

1. 데이터 바인딩 예외(BindException) 처리 핸들러 추가
문제점: @ModelAttribute를 사용하는 GET 요청에서 Enum 타입 변환 실패 등 데이터 바인딩 오류가 발생했을 때, Spring의 기본 에러 메시지가 그대로 노출되는 문제가 있었음.

해결: BindException을 처리하는 전용 핸들러를 추가했음. 이제 타입 변환 실패 시에도 RsData 형식에 맞는 사용자 친화적인 에러 메시지를 반환.

2. GlobalExceptionHandler의 HttpServletRequest 주입 방식 수정
문제점: @RestControllerAdvice(싱글톤 스코프)가 생성자에서 HttpServletRequest(요청 스코프)를 주입받으려 하여 Bean 생성 오류가 발생하는 근본적인 원인이 있었음. 이로 인해 핸들러 전체가 동작하지 않았음.

해결: 생성자 주입을 제거하고, HttpServletRequest가 필요한 특정 핸들러 메서드에만 파라미터로 받도록 수정하여 스코프 충돌 문제를 해결하고 핸들러가 정상 동작하도록 수정했음.

3. 예외 핸들러 응답 형식 리팩토링 및 통일
문제점: 일부 핸들러는 RsData를 직접 반환하고, 다른 핸들러는 ResponseEntity로 RsData를 감싸서 반환하는 등 응답 형식이 일관되지 않았음.

해결: 다음과 같은 원칙으로 응답 형식을 통일하여 코드의 가독성과 일관성을 높였음.

정적 상태 코드: 400, 404 등 반환할 HTTP 상태 코드가 고정된 경우에는 @ResponseStatus 어노테이션을 사용하고, 메서드는 RsData를 직접 반환하도록 수정.

동적 상태 코드: AuthException처럼 예외 객체 자체에 따라 상태 코드가 동적으로 변해야 하는 경우에만 ResponseEntity를 사용하여 상태 코드를 설정하도록 유지함.

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
