### PR TITLE
Feat 155 탈퇴 및 밴 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 
@@ -35,13 +36,56 @@ public class AuthService {
     private final MajorRepository majorRepository;
     private final RedisMailRepository redisMailRepository;
 
+
     @Transactional
     public void signUp(SignUpRequest request) {
 
-        // 회원가입되어있는지 검증
-        if (userRepository.existsByEmail(request.email())) {
-            throw new ExistEmailSignUpException();
+        userRepository.findByEmail(request.email())
+                // 1. 이메일에 해당하는 유저가 존재할 경우 (Optional이 비어있지 않을 경우)
+                .ifPresentOrElse(
+                        user -> {
+                            // 1-1. 유저가 존재하지만, 탈퇴 상태(WITHDRAWAL)인 경우
+                            if (user.getStatus() == UserStatus.WITHDRAWAL) {
+                                reSignUp(user, request); // 재가입 로직 실행
+                            } else {
+                                // 1-2. 유저가 존재하며, 탈퇴 상태가 아닌 경우 (ACTIVE, BANNED 등)
+                                throw new ExistEmailSignUpException();
+                            }
+                        },
+                        // 2. 이메일에 해당하는 유저가 존재하지 않을 경우 (Optional이 비어있을 경우)
+                        () -> firstSignUp(request)
+                );
+
+    }
+
+
+    @Transactional
+    public void reSignUp(User withdrawnUser , SignUpRequest request) {
+
+        // 이메일 인증을 다시 했는지 확인하는 로직이 필요하다면 여기에 추가
+        if (!redisMailRepository.isVerifiedEmail(request.email(), EmailAuthPurpose.SIGN_UP)) {
+            throw new EmailNotVerifiedException();
         }
+
+        Major major = majorRepository.findById(request.majorId())
+                .orElseThrow(MajorNotFoundException::new);
+
+        // 기존 User 엔티티의 상태를 업데이트 (새로 생성하는 것이 아님)
+        withdrawnUser.reactivate(
+                 passwordEncoder.encode(request.password()),
+                 request.name(),
+                 request.studentId(),
+                 major,
+                Grade.fromValue(request.grade()),
+                Semester.fromValue(request.semester()),
+                Role.USER
+                );
+
+        redisMailRepository.deleteVerifiedEmail(request.email(), EmailAuthPurpose.SIGN_UP);
+    }
+
+    @Transactional
+    public void firstSignUp(SignUpRequest request) {
 
         // 이메일 인증 여부 확인
         if (!redisMailRepository.isVerifiedEmail(request.email(), EmailAuthPurpose.SIGN_UP)) {

--- a/backend/src/main/java/com/example/demo/domain/post/dto/response/CommentResponse.java
+++ b/backend/src/main/java/com/example/demo/domain/post/dto/response/CommentResponse.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.post.dto.response;
 
 import com.example.demo.domain.post.entity.PostComment;
+import com.example.demo.domain.user.enums.UserStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -22,11 +23,16 @@ public record CommentResponse(
         LocalDateTime modifiedAt
 ) {
     public static CommentResponse from(PostComment comment) {
+        String author = switch (comment.getUser().getStatus()) {
+            case WITHDRAWAL -> "탈퇴한 사용자";
+            case BANNED -> "밴 당한 사용자";
+            default -> comment.getUser().getName();
+        };
         return new CommentResponse(
                 comment.getId(),
                 comment.getUser().getId(), // 만약 댓글에서 바로 채팅으로 넘어간다면 필요함.
                 comment.getContent(),
-                comment.getUser().getName(), // 닉네임 받아옴
+                author, // 닉네임 받아옴
                 comment.getCreatedAt(),
                 comment.getModifiedAt()
         );

--- a/backend/src/main/java/com/example/demo/domain/post/dto/response/PostListResponse.java
+++ b/backend/src/main/java/com/example/demo/domain/post/dto/response/PostListResponse.java
@@ -3,6 +3,7 @@ package com.example.demo.domain.post.dto.response;
 import com.example.demo.domain.post.enums.PostStatus;
 import com.example.demo.domain.user.enums.Grade;
 import com.example.demo.domain.user.enums.Semester;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/backend/src/main/java/com/example/demo/domain/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/com/example/demo/domain/post/dto/response/PostResponse.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.post.dto.response;
 
 import com.example.demo.domain.post.entity.Post;
+import com.example.demo.domain.user.enums.UserStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -33,6 +34,8 @@ public record PostResponse(
         String majorName,
         @Schema(description = "판매상태", example = "판매중")
         String PostStatus,
+        @Schema(description = "판매자 닉네임",example = "박스프링")
+        String sellerName,
         @Schema(description = "댓글들")
         List<CommentResponse> comments
 ) {
@@ -41,6 +44,11 @@ public record PostResponse(
         List<CommentResponse> commentResponses = post.getComments().stream()
                 .map(CommentResponse::from)
                 .toList();
+        String author = switch (post.getSeller().getStatus()) {
+            case WITHDRAWAL -> "탈퇴한 사용자";
+            case BANNED -> "밴 당한 사용자";
+            default -> post.getSeller().getName();
+        };
         return new PostResponse(
                 post.getId(),
                 post.getTitle(),
@@ -54,6 +62,7 @@ public record PostResponse(
                 post.getLikeCount(),
                 post.getMajor().getName(),
                 post.getStatus().getValue(),
+                author,
                 commentResponses
         );
     }

--- a/backend/src/main/java/com/example/demo/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/demo/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.user.controller;
 
 import com.example.demo.domain.user.dto.ChangeInfoRequest;
+import com.example.demo.domain.user.dto.UserWithdrawalRequest;
 import com.example.demo.global.annotation.swagger.ApiErrorResponse;
 import com.example.demo.global.annotation.swagger.ApiSuccessResponse;
 import com.example.demo.global.annotation.swagger.ApiUnauthorizedResponse;
@@ -10,9 +11,12 @@ import com.example.demo.domain.user.service.UserService;
 import com.example.demo.global.response.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @Tag(name = "User", description = "사용자 정보 API")
 @RequiredArgsConstructor
@@ -46,7 +50,7 @@ public class UserController {
     @GetMapping("/information")
     public RsData<UserInfoResponse> infomation(@AuthenticationPrincipal CustomUserDetails userDetails) {
         UserInfoResponse userInfoResponse = userService.getUserInfo(userDetails.getId());
-        return RsData.of("200", "회원정보 조회 성공",userInfoResponse);
+        return RsData.of("200", "회원정보 조회 성공", userInfoResponse);
     }
 
     @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자의 이름, 학년, 학기, 전공을 수정합니다.")
@@ -70,8 +74,19 @@ public class UserController {
     )
     @ApiUnauthorizedResponse
     @PatchMapping("/information")
-    public RsData<UserInfoResponse> changeInfomation(@AuthenticationPrincipal CustomUserDetails userDetails,@RequestBody ChangeInfoRequest request) {
-        UserInfoResponse userInfoResponse = userService.changeInformation(userDetails.getId(),request);
-        return RsData.of("200", "회원정보 수정 성공",userInfoResponse);
+    public RsData<UserInfoResponse> changeInfomation(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody ChangeInfoRequest request) {
+        UserInfoResponse userInfoResponse = userService.changeInformation(userDetails.getId(), request);
+        return RsData.of("200", "회원정보 수정 성공", userInfoResponse);
+    }
+
+    @PostMapping("/withdrawal")
+    public RsData<?> withdrawUserWithPassword(
+            @RequestBody UserWithdrawalRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        userService.withdraw(userDetails.getId(), request.password());
+
+        return RsData.of("200", "회원 탈퇴가 성공적으로 처리되었습니다.");
+
     }
 }

--- a/backend/src/main/java/com/example/demo/domain/user/dto/UserWithdrawalRequest.java
+++ b/backend/src/main/java/com/example/demo/domain/user/dto/UserWithdrawalRequest.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원탈퇴 요청 DTO")
+public record UserWithdrawalRequest(
+
+        @Schema(description = "비밀번호", example = "!@asdasd2")
+        String password
+) {
+}

--- a/backend/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/backend/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -78,6 +78,17 @@ public class User {
         this.status = UserStatus.WITHDRAWAL;
     }
 
+    public void reactivate(String password, String name, String studentId,Major major, Grade grade, Semester semester, Role role) {
+        this.password = password;
+        this.name = name;
+        this.studentId = studentId;
+        this.major = major;
+        this.grade = grade;
+        this.semester = semester;
+        this.role = role;
+        this.status = UserStatus.ACTIVE;
+    }
+
     public void changePassword(String newEncodedPassword) {
         this.password = newEncodedPassword;
     }

--- a/backend/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/backend/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class User {
 
     @Id
-    @GeneratedValue(generator = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(name = "user_id", columnDefinition = "BINARY(16)")
     private UUID id;
@@ -62,6 +62,21 @@ public class User {
         this.status = UserStatus.BANNED;
     }
 
+    public void withdraw() {
+
+        String uniqueAnonymousId = "withdrawn_" + this.id.toString();
+
+        this.name = "탈퇴한 사용자";
+        this.password = uniqueAnonymousId;// 복구 불가능
+        this.studentId = uniqueAnonymousId;
+
+        this.major = null; // @ManyToOne 관계는 null로 설정하여 연결을 끊음.
+        this.grade = Grade.GRADE_0;
+        this.semester = Semester.Semester_0;
+        this.role = Role.WITHDRAWAL;
+
+        this.status = UserStatus.WITHDRAWAL;
+    }
 
     public void changePassword(String newEncodedPassword) {
         this.password = newEncodedPassword;

--- a/backend/src/main/java/com/example/demo/domain/user/enums/Grade.java
+++ b/backend/src/main/java/com/example/demo/domain/user/enums/Grade.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.stream.Stream;
 
 public enum Grade {
+    GRADE_0(0),
     GRADE_1(1),
     GRADE_2(2),
     GRADE_3(3),

--- a/backend/src/main/java/com/example/demo/domain/user/enums/Semester.java
+++ b/backend/src/main/java/com/example/demo/domain/user/enums/Semester.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.stream.Stream;
 
 public enum Semester {
+    Semester_0(0),
     SEMESTER_1(1),
     SEMESTER_2(2);
 

--- a/backend/src/main/java/com/example/demo/domain/user/enums/UserStatus.java
+++ b/backend/src/main/java/com/example/demo/domain/user/enums/UserStatus.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.user.enums;
 
 public enum UserStatus {
-    ACTIVE,   // 활성
-    BANNED    // 정지
+    ACTIVE,    // 활성
+    BANNED,    // 정지
+    WITHDRAWAL // 탈퇴
 }

--- a/backend/src/main/java/com/example/demo/domain/user/exception/PasswordNotEqualException.java
+++ b/backend/src/main/java/com/example/demo/domain/user/exception/PasswordNotEqualException.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.user.exception;
+
+import com.example.demo.global.exception.AuthException;
+
+public class PasswordNotEqualException extends AuthException {
+    public PasswordNotEqualException() {
+        super("비밀번호가 틀렸습니다","403");
+    }
+}

--- a/backend/src/main/java/com/example/demo/domain/user/role/Role.java
+++ b/backend/src/main/java/com/example/demo/domain/user/role/Role.java
@@ -1,5 +1,5 @@
 package com.example.demo.domain.user.role;
 
 public enum Role {
-    USER, ADMIN
+    USER, ADMIN, WITHDRAWAL
 }

--- a/backend/src/main/java/com/example/demo/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/example/demo/domain/user/service/UserService.java
@@ -9,9 +9,11 @@ import com.example.demo.domain.user.dto.ChangeInfoRequest;
 import com.example.demo.domain.user.enums.Grade;
 import com.example.demo.domain.user.enums.Semester;
 import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.exception.PasswordNotEqualException;
 import com.example.demo.domain.user.repository.UserRepository;
 import com.example.demo.domain.user.response.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,4 +65,13 @@ public class UserService {
     }
 
 
+    @Transactional
+    public void withdraw(UUID userId, String password) {
+
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        if(!user.getPassword().equals(password)) throw new PasswordNotEqualException();
+
+        user.withdraw();
+    }
 }

--- a/backend/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -199,7 +198,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public RsData<?> handleAllUncaughtException(Exception e, HttpServletRequest request) { // 필요한 곳에서만 request를 파라미터로 받음
         log.error("🔥 500 Internal Server Error 발생: {}", e.getMessage(), e);
-        log.error("Request: {} {}", request.getMethod(), request.getRequestURI()); // 요청 정보 로깅
+        log.error("🔥🔥🔥Request: {} {}", request.getMethod(), request.getRequestURI()); // 요청 정보 로깅
         return RsData.of("500", "서버 내부 오류가 발생했습니다.");
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항 설명

### 회원탈퇴
1. 유저 상태에서 회원 탈퇴 추가
2. 탈퇴기능 구현
3. 탈퇴시 id와 이메일을 제외한 나머지를 변경 혹은 날려버림.

### 회원가입
1. 회원가입시 이메일을가지고 유저레포지토리에서 사용자를 찾음
2. 밴된 유저면 예외처리
3. 탈퇴한 유저면 재가입로직으로
4. 신규유저면 기존에 사용하던 회원가입 로직 사용

### 게시물,댓글
1. 탈퇴,밴유저면 작성자 이름을 해당 상태에 맞게 응답


## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
