### PR TITLE
Feat 179 닉네임 중복 검사 기능 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/controller/AuthController.java
@@ -169,7 +169,7 @@ public class AuthController implements AuthControllerDoc{
         return RsData.of("200", "비밀번호 초기화 완료되었습니다.");
     }
 
-    @GetMapping("/{name}/exists/")
+    @GetMapping("/{name}/exists")
     public RsData<?> nameExists(@PathVariable String name){
         boolean isexists = authService.isDuplicateName(name);
         return RsData.of("200","닉네임 중복 검사 성공",isexists);

--- a/backend/src/main/java/com/example/demo/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/controller/AuthController.java
@@ -169,6 +169,12 @@ public class AuthController implements AuthControllerDoc{
         return RsData.of("200", "비밀번호 초기화 완료되었습니다.");
     }
 
+    @GetMapping("/{name}/exists/")
+    public RsData<?> nameExists(@PathVariable String name){
+        boolean isexists = authService.isDuplicateName(name);
+        return RsData.of("200","닉네임 중복 검사 성공",isexists);
+    }
+
     @Operation(summary = "관리자 전용 API 테스트", description = "ADMIN 권한을 가진 사용자만 접근 가능한 테스트용 API입니다.")
     @ApiSuccessResponse( description = " 관리자 권한으로 접근 성공")
     @ApiErrorResponse(

--- a/backend/src/main/java/com/example/demo/domain/auth/exception/ArealyExistsName.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/exception/ArealyExistsName.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.auth.exception;
+
+import com.example.demo.global.exception.AuthException;
+
+public class ArealyExistsName extends AuthException {
+    public ArealyExistsName(String message) {
+        super(message + "는 이미 사용중인 닉네임입니다.","409");
+    }
+}

--- a/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
@@ -167,4 +167,9 @@ public class AuthService {
             userRepository.save(user); // 준영속상태이기에 save로 영속 상태로 만들고, 변경 사항을 DB에 반영
         }
     }
+
+    @Transactional(readOnly = true)
+    public boolean isDuplicateName(String name) {
+        return userRepository.existsByName(name);
+    }
 }

--- a/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/demo/domain/auth/service/AuthService.java
@@ -62,13 +62,15 @@ public class AuthService {
     @Transactional
     public void reSignUp(User withdrawnUser , SignUpRequest request) {
 
-        // 이메일 인증을 다시 했는지 확인하는 로직이 필요하다면 여기에 추가
-        if (!redisMailRepository.isVerifiedEmail(request.email(), EmailAuthPurpose.SIGN_UP)) {
-            throw new EmailNotVerifiedException();
-        }
+        // 이메일 인증을 다시 했는지 확인
+        didVerifyEmail(request.email(), EmailAuthPurpose.SIGN_UP);
 
         Major major = majorRepository.findById(request.majorId())
                 .orElseThrow(MajorNotFoundException::new);
+
+        if(isDuplicateName(request.name())) {
+            throw new ArealyExistsName(request.name());
+        }
 
         // 기존 User 엔티티의 상태를 업데이트 (새로 생성하는 것이 아님)
         withdrawnUser.reactivate(
@@ -89,16 +91,24 @@ public class AuthService {
         redisMailRepository.deleteVerifiedEmail(request.email(), EmailAuthPurpose.SIGN_UP);
     }
 
+    private void didVerifyEmail(String request, EmailAuthPurpose signUp) {
+        if (!redisMailRepository.isVerifiedEmail(request, signUp)) {
+            throw new EmailNotVerifiedException();
+        }
+    }
+
     @Transactional
     public void firstSignUp(SignUpRequest request) {
 
         // 이메일 인증 여부 확인
-        if (!redisMailRepository.isVerifiedEmail(request.email(), EmailAuthPurpose.SIGN_UP)) {
-            throw new EmailNotVerifiedException();
-        }
+        didVerifyEmail(request.email(), EmailAuthPurpose.SIGN_UP);
 
         Major major = majorRepository.findById(request.majorId())
                 .orElseThrow(MajorNotFoundException::new);
+
+        if(isDuplicateName(request.name())) {
+            throw new ArealyExistsName(request.name());
+        }
 
         User user = User.builder()
                 .email(request.email())
@@ -137,9 +147,7 @@ public class AuthService {
     public void resetPassword(@Valid ResetPasswordRequest request) {
 
         // 이메일 인증 여부 확인
-        if (!redisMailRepository.isVerifiedEmail(request.email(), EmailAuthPurpose.PASSWORD_RESET)) {
-            throw new EmailNotVerifiedException();
-        }
+        didVerifyEmail(request.email(), EmailAuthPurpose.PASSWORD_RESET);
 
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(UserNotFoundException::new);

--- a/backend/src/main/java/com/example/demo/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/demo/domain/user/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByName(String sellerName);
 
     boolean existsById(UUID id);
+
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/example/demo/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/example/demo/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.user.service;
 
+import com.example.demo.domain.auth.exception.ArealyExistsName;
 import com.example.demo.domain.auth.exception.MemberNotFoundException;
 import com.example.demo.domain.auth.exception.UserNotFoundException;
 import com.example.demo.domain.major.entity.Major;
@@ -55,7 +56,9 @@ public class UserService {
 
 //        Grade newGrade = (request.grade() != null) ? Grade.fromValue(request.grade()) : null;
 //        Semester newSemester = (request.semester() != null) ? Semester.fromValue(request.semester()) : null;
-        
+        if(userRepository.existsByName(request.name())) {
+            throw new ArealyExistsName(request.name());
+        }
         currentUser.updateProfile(request.name(), newMajor, request.grade(), request.semester());
 
         return UserInfoResponse.from(currentUser);

--- a/backend/src/main/java/com/example/demo/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/global/security/SecurityConfig.java
@@ -135,6 +135,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/login",
                                 "/api/auth/signup",
+                                "/api/auth/*/exists",
                                 "/api/auth/reissue",
                                 "/api/mail/**"
                         ).permitAll()


### PR DESCRIPTION
## ✨ 변경 사항 설명

1. 닉네임 중복 요청 경로 추가 
프론트에서 사용자 입력이 멈춘지 1초가 지나면 자동으로 요청을 보내던 
중복겁사 버튼을 누를때 오도록 하던 사용하길 요망
2. 회원가입 및 회원정보 변경시 닉네임 중복 검사 로직 삽입

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
