### PR TITLE
채팅방 목록조회 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/example/demo/domain/chat/controller/ChatController.java
@@ -5,6 +5,7 @@
         import com.example.demo.domain.chat.entity.ChatMessage;
         import com.example.demo.domain.chat.entity.ChatRoom;
         import com.example.demo.domain.chat.exception.ChatRoomNotFoundException;
+        import com.example.demo.domain.chat.repository.ChatMessageRepository;
         import com.example.demo.domain.chat.service.ChatRoomService;
         import com.example.demo.domain.chat.service.ChatService;
         import com.example.demo.domain.post.entity.Post;
@@ -55,6 +56,7 @@
             private final UserRepository userRepository;
             private final PostRepository postRepository;
             private final UserReportRepository userReportRepository;
+            private final ChatMessageRepository chatMessageRepository;
             private static final Logger log = LoggerFactory.getLogger(ChatController.class);
 
 
@@ -173,14 +175,31 @@
                             .map(User::getName)
                             .orElse("알 수 없음");
 
+                    // 최신 메시지 조회
+                    String lastMessage = null;
+                    String lastTimestamp = null;
+                    Optional<ChatMessage> latestMessage = chatMessageRepository.findFirstByChatRoomIdOrderBySentAtDesc(room.getRoomId());
+                    if (latestMessage.isPresent()) {
+                        ChatMessage message = latestMessage.get();
+                        // 텍스트 메시지면 content, 이미지면 "사진" 표시
+                        if (message.getContent() != null && !message.getContent().isBlank()) {
+                            lastMessage = message.getContent();
+                        } else if (message.getImageUrl() != null) {
+                            lastMessage = "사진";
+                        }
+                        if (message.getSentAt() != null) {
+                            lastTimestamp = message.getSentAt().toString();
+                        }
+                    }
+
                     return new ListChatRoomsResponseDto.ChatRoomDto(
                             room.getRoomId().toString(),
                             room.getPostId() != null ? room.getPostId().toString() : null,
                             name,
                             postName,
                             room.getUserCount(),
-                            room.getLastMessage(),
-                            room.getLastTimestamp()
+                            lastMessage,
+                            lastTimestamp
                     );
                 }).collect(Collectors.toList());
 

--- a/backend/src/main/java/com/example/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/example/demo/domain/chat/repository/ChatMessageRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -17,5 +18,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> 
 
     // 채팅방에서 특정 시각 이전(포함) 메시지 모두 조회
     List<ChatMessage> findByChatRoomIdAndSentAtLessThanEqual(UUID chatRoomId, LocalDateTime lastReadAt);
+
+    // 특정 채팅방의 최신 메시지 조회 (sentAt 내림차순 정렬 후 첫 번째)
+    Optional<ChatMessage> findFirstByChatRoomIdOrderBySentAtDesc(UUID roomId);
 
 }


### PR DESCRIPTION
## ✨ 변경 사항 설명

1. ChatMessageRepository에 최신 메시지 조회 메서드 추가
findFirstByChatRoomIdOrderBySentAtDesc(): 채팅방의 최신 메시지를 sentAt 기준 내림차순으로 조회

2. ChatController 수정
ChatMessageRepository 주입
/rooms 엔드포인트에서 각 채팅방의 최신 메시지를 DB에서 실시간 조회하도록 변경
텍스트 메시지는 content 반환, 이미지 메시지는 "사진" 반환
lastTimestamp는 메시지의 sentAt 값을 문자열로 변환해 반환

## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
